### PR TITLE
fix: S3 배포 시 app 폴더 대신 루트에 dist 파일 업로드하도록 변경

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,4 +40,3 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           SOURCE_DIR: "dist"
-          DEST_DIR: "app"


### PR DESCRIPTION
- S3에 배포할 때 DEST_DIR: "app" 설정을 제거하여 dist 디렉터리의 파일들이 버킷 루트에 업로드되도록 수정했습니다.
- 이 변경으로 S3 정적 웹사이트 호스팅에서 index.html 등 주요 파일을 루트 경로에서 바로 찾을 수 있습니다.
- 기존 app/ 경로는 더 이상 사용하지 않습니다.
- S3 정적 웹사이트 호스팅을 사용하는 프로젝트에서는 필히 index document를 index.html로 설정하시기 바랍니다.